### PR TITLE
Bump to 1.1.1.

### DIFF
--- a/.github/workflows/NetMiniZ.yml
+++ b/.github/workflows/NetMiniZ.yml
@@ -17,11 +17,11 @@ jobs:
            nuget restore
            dotnet build -c Release 
       - name: Build Contents
-        run: ls -lart NetMiniZ.Tests/bin/x64/Release/netcoreapp3.1
+        run: ls -lart NetMiniZ.Tests/bin/Release/netcoreapp3.1
         shell: bash
       - name: Test
         run: |
-           $HOME/.nuget/packages/microsoft.testplatform/16.7.0/tools/net451/Common7/IDE/Extensions/TestPlatform/vstest.console.exe NetMiniZ.Tests/bin/x64/Release/netcoreapp3.1/NetMiniZ.Tests.dll
+           $HOME/.nuget/packages/microsoft.testplatform/16.7.0/tools/net451/Common7/IDE/Extensions/TestPlatform/vstest.console.exe NetMiniZ.Tests/bin/Release/netcoreapp3.1/NetMiniZ.Tests.dll
         shell: bash
 
   netminiz-win-x86:
@@ -35,13 +35,13 @@ jobs:
       - name: Build
         run: |
            nuget restore
-           dotnet build -c Release -p:Platform=x86
+           dotnet build -c Release -p:PlatformTarget=x86
       - name: Build Contents
-        run: ls -lart NetMiniZ.Tests/bin/x86/Release/netcoreapp3.1
+        run: ls -lart NetMiniZ.Tests/bin/Release/netcoreapp3.1
         shell: bash
       - name: Test
         run: |
-           $HOME/.nuget/packages/microsoft.testplatform/16.7.0/tools/net451/Common7/IDE/Extensions/TestPlatform/vstest.console.exe NetMiniZ.Tests/bin/x86/Release/netcoreapp3.1/NetMiniZ.Tests.dll
+           $HOME/.nuget/packages/microsoft.testplatform/16.7.0/tools/net451/Common7/IDE/Extensions/TestPlatform/vstest.console.exe --settings:NetMiniZ.Tests/x86.runsettings NetMiniZ.Tests/bin/Release/netcoreapp3.1/NetMiniZ.Tests.dll
         shell: bash
 
   netminiz-osx-x64:
@@ -57,10 +57,10 @@ jobs:
            nuget restore
            msbuild /p:Configuration=Release
       - name: Build Contents
-        run: ls -lart NetMiniZ.Tests/bin/x64/Release/netcoreapp3.1
+        run: ls -lart NetMiniZ.Tests/bin/Release/netcoreapp3.1
       - name: Test
         run: |
-           mono $HOME/.nuget/packages/microsoft.testplatform/16.7.0/tools/net451/Common7/IDE/Extensions/TestPlatform/vstest.console.exe NetMiniZ.Tests/bin/x64/Release/netcoreapp3.1/NetMiniZ.Tests.dll
+           mono $HOME/.nuget/packages/microsoft.testplatform/16.7.0/tools/net451/Common7/IDE/Extensions/TestPlatform/vstest.console.exe NetMiniZ.Tests/bin/Release/netcoreapp3.1/NetMiniZ.Tests.dll
 
   netminiz-linux-x64:
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
            nuget restore
            msbuild /p:Configuration=Release
       - name: Build Contents
-        run: ls -lart NetMiniZ.Tests/bin/x64/Release/netcoreapp3.1
+        run: ls -lart NetMiniZ.Tests/bin/Release/netcoreapp3.1
       - name: Test
         run: |
-           mono $HOME/.nuget/packages/microsoft.testplatform/16.7.0/tools/net451/Common7/IDE/Extensions/TestPlatform/vstest.console.exe NetMiniZ.Tests/bin/x64/Release/netcoreapp3.1/NetMiniZ.Tests.dll
+           mono $HOME/.nuget/packages/microsoft.testplatform/16.7.0/tools/net451/Common7/IDE/Extensions/TestPlatform/vstest.console.exe NetMiniZ.Tests/bin/Release/netcoreapp3.1/NetMiniZ.Tests.dll

--- a/src/NetMiniZ.Tests/NetMiniZ.Tests.csproj
+++ b/src/NetMiniZ.Tests/NetMiniZ.Tests.csproj
@@ -2,14 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>  
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../NetMiniZ/NetMiniZ.csproj" />
     <PackageReference Include="Microsoft.TestPlatform" Version="16.7.0" />
@@ -17,10 +9,10 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) And '$(Platform)' == 'x86'">
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) And '$(PlatformTarget)' == 'x86'">
     <Content Include="../../deps/libminiz/win-x86/libminiz-2.1.0.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) And '$(Platform)' == 'x64'">
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) And '$(PlatformTarget)' != 'x86'">
     <Content Include="../../deps/libminiz/win-x64/libminiz-2.1.0.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">

--- a/src/NetMiniZ.Tests/x86.runsettings
+++ b/src/NetMiniZ.Tests/x86.runsettings
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <TargetPlatform>x86</TargetPlatform>
+  </RunConfiguration>
+</RunSettings>

--- a/src/NetMiniZ.sln
+++ b/src/NetMiniZ.sln
@@ -7,27 +7,37 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetMiniZ.Tests", "NetMiniZ.
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|x64.ActiveCfg = Debug|x64
-		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|x64.Build.0 = Debug|x64
-		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|x86.ActiveCfg = Debug|x86
-		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|x86.Build.0 = Debug|x86
-		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|x64.ActiveCfg = Release|x64
-		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|x64.Build.0 = Release|x64
-		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|x86.ActiveCfg = Release|x86
-		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|x86.Build.0 = Release|x86
-		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|x64.ActiveCfg = Debug|x64
-		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|x64.Build.0 = Debug|x64
-		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|x86.ActiveCfg = Debug|x86
-		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|x86.Build.0 = Debug|x86
-		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|x64.ActiveCfg = Release|x64
-		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|x64.Build.0 = Release|x64
-		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|x86.ActiveCfg = Release|x86
-		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|x86.Build.0 = Release|x86
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|x64.Build.0 = Debug|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|x86.Build.0 = Debug|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|x64.ActiveCfg = Release|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|x64.Build.0 = Release|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|x86.ActiveCfg = Release|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|x86.Build.0 = Release|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2ADBF037-6AE0-4C96-A72D-C584297A2ED1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|x86.Build.0 = Debug|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|x64.Build.0 = Release|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|x86.Build.0 = Release|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA3D6003-23B3-43E0-A17B-9C6A112719E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/NetMiniZ/NetMiniZ.csproj
+++ b/src/NetMiniZ/NetMiniZ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Cross platform version of Miniz based on MiniZ.Net by ActuallyaDeviloper. https://github.com/ActuallyaDeviloper/MiniZ.Net</Description>
-    <AssemblyVersion>1.1.0</AssemblyVersion>
+    <AssemblyVersion>1.1.1</AssemblyVersion>
     <Authors>Jason Millard</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -14,14 +14,6 @@
     <PackageProjectUrl>https://github.com/jsm174/net-miniz</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <InformationalVersion>$(AssemblyVersion)</InformationalVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
   </PropertyGroup>
   <ItemGroup>
     <Content Include="../../deps/libminiz/win-x86/libminiz-2.1.0.dll">


### PR DESCRIPTION
Updated to AnyCPU to avoid having DLLs specifically built as 64 or 32 bit.

Added `x86.runsettings` so `vstest.console.exe` will launch as 32 bit process.